### PR TITLE
Update obsidian.el to remove the f.el dependency

### DIFF
--- a/obsidian.el
+++ b/obsidian.el
@@ -492,7 +492,7 @@ If the file include directories in its path, we create the file relative to
                      (s-concat obsidian-directory "/"
                                obsidian-inbox-directory "/" f)))
          (cleaned (s-replace "//" "/" filename)))
-    (if (not (f-exists-p cleaned))
+    (if (not (file-exists-p cleaned))
         (progn
           (f-mkdir-full-path (f-dirname cleaned))
           (f-touch cleaned)


### PR DESCRIPTION
Commit d4ebbfa for issue #63 use the f-exists-p function that doesn't exists in standard Emacs but only in f.el library. Since this is simply an alias to file-exists-p, let's use this last one so that we don't need to depend from f.el.